### PR TITLE
Fix mkl1_active progress print

### DIFF
--- a/data_processing.py
+++ b/data_processing.py
@@ -182,7 +182,10 @@ def create_activity_labels(df):
     if 'mkl1_10' in df.columns:
         df['mkl1_active'] = (df['mkl1_10'] < toxicity_threshold).astype(int)
         active_count = df['mkl1_active'].sum()
-        print(f"  • mkl1_active: {active_count}/{len(df)*100:.1f}%)")
+        print(
+            f"  • mkl1_active: {active_count}/{len(df)} "
+            f"({active_count/len(df)*100:.1f}%)"
+        )
     
     return df
 


### PR DESCRIPTION
## Summary
- fix incorrect print format for MKL1 activity count in `create_activity_labels`

## Testing
- `python3 -m py_compile data_processing.py`


------
https://chatgpt.com/codex/tasks/task_e_6841db04668483288c73244522533d4d